### PR TITLE
No need to subclass Disposable

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,15 +10,13 @@ const command = createCommandDecorator(commandRegistry);
 const repositoryRegex = /^(?:https:\/\/github.com\/)?(.+?)\/(.+)/i;
 const ownerRegex = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
 
-export class Commands extends Disposable {
+export class Commands {
 
     private readonly _disposable: Disposable;
 
     constructor(
         private readonly _github: GitHubApi
     ) {
-        super(() => this.dispose);
-
         this._disposable = Disposable.from(
             ...commandRegistry.map(({ name, key, method }) => commands.registerCommand(name, (...args: any[]) => method.apply(this, args)))
         );

--- a/src/gitHubApi.ts
+++ b/src/gitHubApi.ts
@@ -6,15 +6,13 @@ import { Logger } from './logger';
 import { Variables } from 'graphql-request/dist/src/types';
 import { GitHubFileSystemProvider } from './githubFileSystemProvider';
 
-export class GitHubApi extends Disposable {
+export class GitHubApi {
 
     private readonly _disposable: Disposable;
     private readonly _latestCommitMap = new Map<WorkspaceFolder, string>();
     private readonly _latestCommitForUriMap = new Map<string, string>();
 
     constructor() {
-        super(() => this.dispose());
-
         this._disposable = Disposable.from(
             configuration.onDidChange(this.onConfigurationChanged, this)
         );

--- a/src/githubFileSystemProvider.ts
+++ b/src/githubFileSystemProvider.ts
@@ -3,7 +3,7 @@ import { Disposable, Event, EventEmitter, FileChangeEvent, FileStat, FileSystemE
 import { GitHubApi } from './gitHubApi';
 import fetch from 'node-fetch';
 
-export class GitHubFileSystemProvider extends Disposable implements FileSystemProvider {
+export class GitHubFileSystemProvider implements FileSystemProvider {
 
     public static readonly Scheme = 'remotehub';
 
@@ -12,8 +12,6 @@ export class GitHubFileSystemProvider extends Disposable implements FileSystemPr
     constructor(
         private readonly _github: GitHubApi
     ) {
-        super(() => this.dispose());
-
         this._disposable = Disposable.from(
             workspace.registerFileSystemProvider(GitHubFileSystemProvider.Scheme, this, { isCaseSensitive: true })
         );

--- a/src/remoteLanguageProvider.ts
+++ b/src/remoteLanguageProvider.ts
@@ -12,15 +12,13 @@ import {
 import { GitHubFileSystemProvider } from './githubFileSystemProvider';
 import { SourcegraphApi } from './sourcegraphApi';
 
-export class RemoteLanguageProvider extends Disposable implements DefinitionProvider, DocumentSymbolProvider, HoverProvider, ReferenceProvider, WorkspaceSymbolProvider {
+export class RemoteLanguageProvider implements DefinitionProvider, DocumentSymbolProvider, HoverProvider, ReferenceProvider, WorkspaceSymbolProvider {
 
     private readonly _disposable: Disposable;
 
     constructor(
         private _sourcegraph: SourcegraphApi
     ) {
-        super(() => this.dispose());
-
         this._disposable = Disposable.from(
             languages.registerDefinitionProvider({ scheme: GitHubFileSystemProvider.Scheme, language: '*' }, this),
             languages.registerDocumentSymbolProvider({ scheme: GitHubFileSystemProvider.Scheme, language: '*' }, this),

--- a/src/sourcegraphApi.ts
+++ b/src/sourcegraphApi.ts
@@ -1,7 +1,7 @@
 'use strict';
 import {
     CancellationToken,
-    Definition, Disposable,
+    Definition,
     Hover,
     Location,
     MarkdownString,
@@ -19,14 +19,13 @@ import fetch from 'node-fetch';
 
 const hoverTypeRegex = /\*\*(.*)?\*\*(?: \_\((.*)\)\_)?/;
 
-export class SourcegraphApi extends Disposable {
+export class SourcegraphApi {
 
     private readonly _capabilitiesMap = new Map<WorkspaceFolder, LspCapabilities>();
 
     constructor(
         public readonly _github: GitHubApi
     ) {
-        super(() => this.dispose());
     }
 
     dispose() {


### PR DESCRIPTION
The registries don't need Disposable.
It's enough with implementing { dispose }.