### PR TITLE
No need to subclass Disposable

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,12 +17,10 @@ import { Command, createCommandDecorator } from './system';
 const commandRegistry: Command[] = [];
 const command = createCommandDecorator(commandRegistry);
 
-export class Commands extends Disposable {
+export class Commands implements Disposable {
     private readonly _disposable: Disposable;
 
     constructor(private readonly _github: GitHubApi) {
-        super(() => this.dispose);
-
         this._disposable = Disposable.from(
             ...commandRegistry.map(({ name, key, method }) =>
                 commands.registerCommand(name, (...args: any[]) =>

--- a/src/gitHubApi.ts
+++ b/src/gitHubApi.ts
@@ -13,14 +13,12 @@ import { Variables } from 'graphql-request/dist/src/types';
 
 const repositoryRegex = /^(?:https:\/\/github.com\/)?(.+?)\/(.+?)(?:\/|$)/i;
 
-export class GitHubApi extends Disposable {
+export class GitHubApi implements Disposable {
     private readonly _disposable: Disposable;
     private readonly _latestCommitMap = new Map<WorkspaceFolder, string>();
     private readonly _latestCommitForUriMap = new Map<string, string>();
 
     constructor() {
-        super(() => this.dispose());
-
         this._disposable = Disposable.from(
             configuration.onDidChange(this.onConfigurationChanged, this)
         );

--- a/src/remoteLanguageProvider.ts
+++ b/src/remoteLanguageProvider.ts
@@ -22,9 +22,10 @@ import {
 import { fileSystemScheme } from './constants';
 import { SourcegraphApi } from './sourcegraphApi';
 
-export class RemoteLanguageProvider extends Disposable
+export class RemoteLanguageProvider 
     implements
         DefinitionProvider,
+        Disposable,
         DocumentSymbolProvider,
         HoverProvider,
         ReferenceProvider,
@@ -32,7 +33,6 @@ export class RemoteLanguageProvider extends Disposable
     private readonly _disposable: Disposable;
 
     constructor(private _sourcegraph: SourcegraphApi) {
-        super(() => this.dispose());
 
         this._disposable = Disposable.from(
             languages.registerDefinitionProvider(

--- a/src/sourcegraphApi.ts
+++ b/src/sourcegraphApi.ts
@@ -22,14 +22,13 @@ import fetch from 'node-fetch';
 
 const hoverTypeRegex = /\*\*(.*)?\*\*(?: \_\((.*)\)\_)?/;
 
-export class SourcegraphApi extends Disposable {
+export class SourcegraphApi implements Disposable {
     private readonly _capabilitiesMap = new Map<
         WorkspaceFolder,
         LspCapabilities
     >();
 
     constructor(public readonly _github: GitHubApi) {
-        super(() => this.dispose());
     }
 
     dispose() {}


### PR DESCRIPTION
The registries don't need Disposable.
It's enough with implementing { dispose }.