### PR TITLE
Make sure the provider is declared as readonly

### DIFF
--- a/src/gitHubFileSystemProvider.ts
+++ b/src/gitHubFileSystemProvider.ts
@@ -27,7 +27,8 @@ export class GitHubFileSystemProvider implements FileSystemProvider, Disposable 
     ) {
         this._disposable = Disposable.from(
             workspace.registerFileSystemProvider(fileSystemScheme, this, {
-                isCaseSensitive: true
+                isCaseSensitive: true,
+                isReadonly: true
             })
             // workspace.onDidCloseTextDocument(this.onClosedTextDocument, this)
         );


### PR DESCRIPTION
@eamodio This will turn editors readonly and prevent operations from the explorer.